### PR TITLE
Add collapsible preview and new templates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "markdown-editor",
       "version": "0.1.0",
       "dependencies": {
+        "@emotion/react": "^11.14.0",
+        "@emotion/styled": "^11.14.0",
         "@mui/icons-material": "^5.14.8",
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^13.4.0",
@@ -2357,12 +2359,45 @@
         "postcss-selector-parser": "^6.0.10"
       }
     },
+    "node_modules/@emotion/babel-plugin": {
+      "version": "11.13.5",
+      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.13.5.tgz",
+      "integrity": "sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.16.7",
+        "@babel/runtime": "^7.18.3",
+        "@emotion/hash": "^0.9.2",
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/serialize": "^1.3.3",
+        "babel-plugin-macros": "^3.1.0",
+        "convert-source-map": "^1.5.0",
+        "escape-string-regexp": "^4.0.0",
+        "find-root": "^1.1.0",
+        "source-map": "^0.5.7",
+        "stylis": "4.2.0"
+      }
+    },
+    "node_modules/@emotion/babel-plugin/node_modules/convert-source-map": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/babel-plugin/node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/@emotion/cache": {
       "version": "11.14.0",
       "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.14.0.tgz",
       "integrity": "sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@emotion/memoize": "^0.9.0",
         "@emotion/sheet": "^1.4.0",
@@ -2371,33 +2406,119 @@
         "stylis": "4.2.0"
       }
     },
+    "node_modules/@emotion/hash": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
+      "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/is-prop-valid": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.3.1.tgz",
+      "integrity": "sha512-/ACwoqx7XQi9knQs/G0qKvv5teDMhD7bXYns9N/wM8ah8iNb8jZ2uNO0YOgiq2o2poIvVtJS2YALasQuMSQ7Kw==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/memoize": "^0.9.0"
+      }
+    },
     "node_modules/@emotion/memoize": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
       "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/react": {
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
+      "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
       "license": "MIT",
-      "peer": true
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "@emotion/babel-plugin": "^11.13.5",
+        "@emotion/cache": "^11.14.0",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/use-insertion-effect-with-fallbacks": "^1.2.0",
+        "@emotion/utils": "^1.4.2",
+        "@emotion/weak-memoize": "^0.4.0",
+        "hoist-non-react-statics": "^3.3.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@emotion/serialize": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.3.3.tgz",
+      "integrity": "sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/hash": "^0.9.2",
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/unitless": "^0.10.0",
+        "@emotion/utils": "^1.4.2",
+        "csstype": "^3.0.2"
+      }
     },
     "node_modules/@emotion/sheet": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.4.0.tgz",
       "integrity": "sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/styled": {
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.0.tgz",
+      "integrity": "sha512-XxfOnXFffatap2IyCeJyNov3kiDQWoR08gPUQxvbL7fxKryGBKUZUkG6Hz48DZwVrJSVh9sJboyV1Ds4OW6SgA==",
       "license": "MIT",
-      "peer": true
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "@emotion/babel-plugin": "^11.13.5",
+        "@emotion/is-prop-valid": "^1.3.0",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/use-insertion-effect-with-fallbacks": "^1.2.0",
+        "@emotion/utils": "^1.4.2"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.0.0-rc.0",
+        "react": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@emotion/unitless": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
+      "integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/use-insertion-effect-with-fallbacks": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.2.0.tgz",
+      "integrity": "sha512-yJMtVdH59sxi/aVJBpk9FQq+OR8ll5GT8oWd57UpeaKEVGab41JWaCFA7FRLoMLloOZF/c/wsPoe+bfGmRKgDg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
     },
     "node_modules/@emotion/utils": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.2.tgz",
       "integrity": "sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@emotion/weak-memoize": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
       "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.7.0",
@@ -9214,6 +9335,12 @@
         "url": "https://github.com/avajs/find-cache-dir?sponsor=1"
       }
     },
+    "node_modules/find-root": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
+      "license": "MIT"
+    },
     "node_modules/find-up": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -9919,6 +10046,21 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/hoist-non-react-statics/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
     },
     "node_modules/hoopy": {
       "version": "0.1.4",
@@ -17915,8 +18057,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
       "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/sucrase": {
       "version": "3.35.0",
@@ -18689,9 +18830,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "license": "Apache-2.0",
       "peer": true,
       "bin": {
@@ -18699,7 +18840,7 @@
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=14.17"
+        "node": ">=4.2.0"
       }
     },
     "node_modules/unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@emotion/react": "^11.14.0",
+    "@emotion/styled": "^11.14.0",
     "@mui/icons-material": "^5.14.8",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",

--- a/src/components/MarkdownEditor.js
+++ b/src/components/MarkdownEditor.js
@@ -7,6 +7,15 @@ import "highlight.js/styles/github.css";
 import "./preview.css";
 import "github-markdown-css/github-markdown-light.css";
 import "./theme.css";
+import "./line.css";
+import "./templates.css";
+
+import FolderOpenIcon from "@mui/icons-material/FolderOpen";
+import SaveIcon from "@mui/icons-material/Save";
+import Brightness4Icon from "@mui/icons-material/Brightness4";
+import Brightness7Icon from "@mui/icons-material/Brightness7";
+import VisibilityIcon from "@mui/icons-material/Visibility";
+import VisibilityOffIcon from "@mui/icons-material/VisibilityOff";
 
 
 function MarkdownEditor() {
@@ -14,9 +23,12 @@ function MarkdownEditor() {
   const [existingMarkdown, setExistingMarkdown] = useState("");
   const [editedMarkdown, setEditedMarkdown] = useState("");
   const [theme, setTheme] = useState("light");
-  const [template, setTemplate] = useState("default");
+  const [template, setTemplate] = useState("github");
+  const [previewVisible, setPreviewVisible] = useState(true);
+  const [lineNumbers, setLineNumbers] = useState([]);
   const editorRef = useRef(null);
   const previewRef = useRef(null);
+  const lineNumberRef = useRef(null);
 
   const toggleTheme = () => {
     setTheme(theme === "light" ? "dark" : "light");
@@ -25,11 +37,13 @@ function MarkdownEditor() {
   const handleEditorScroll = () => {
     const scrollTop = editorRef.current.scrollTop;
     previewRef.current.scrollTop = scrollTop;
+    lineNumberRef.current.scrollTop = scrollTop;
   };
 
   const handlePreviewScroll = () => {
     const scrollTop = previewRef.current.scrollTop;
     editorRef.current.scrollTop = scrollTop;
+    lineNumberRef.current.scrollTop = scrollTop;
   };
 
   const handleLoadMarkdown = () => {
@@ -92,6 +106,11 @@ function MarkdownEditor() {
   };
 
   useEffect(() => {
+    const lines = markdown.split("\n").length || 1;
+    setLineNumbers(Array.from({ length: lines }, (_, i) => i + 1));
+  }, [markdown]);
+
+  useEffect(() => {
     // コンポーネントがマウントされた際にhighlight.jsを初期化
     hljs.highlightAll();
   }, [markdown]);
@@ -107,40 +126,63 @@ function MarkdownEditor() {
             onChange={(e) => setTemplate(e.target.value)}
             className="mx-2"
           >
-            <option value="default">Default</option>
             <option value="github">GitHub</option>
+            <option value="simple">Simple</option>
+            <option value="word">Word</option>
           </Form.Select>
           <Button variant="secondary" className="mx-2" onClick={toggleTheme}>
-            {theme === "light" ? "Dark" : "Light"}
+            {theme === "light" ? <Brightness4Icon /> : <Brightness7Icon />}
           </Button>
           <Button className="mx-2" onClick={handleLoadMarkdown} variant="primary">
-            読込
+            <FolderOpenIcon />
           </Button>
           <Button className="mx-2" onClick={handleSaveMarkdown} variant="success">
-            保存
+            <SaveIcon />
+          </Button>
+          <Button
+            className="mx-2"
+            onClick={() => setPreviewVisible(!previewVisible)}
+            variant="info"
+          >
+            {previewVisible ? <VisibilityOffIcon /> : <VisibilityIcon />}
           </Button>
         </Nav>
       </Navbar>
       <Row className="mt-2">
-        <Col md={6} className="p-0">
-          <Form.Control
-            as="textarea"
-            placeholder="Enter markdown here..."
-            ref={editorRef}
-            onScroll={handleEditorScroll}
-            className="editor"
-            value={markdown}
-            onChange={(e) => setMarkdown(e.target.value)}
-          />
+        <Col md={previewVisible ? 6 : 12} className="p-0">
+          <div className="editor-container">
+            <div ref={lineNumberRef} className="line-numbers">
+              {lineNumbers.map((n) => (
+                <span key={n}>{n}</span>
+              ))}
+            </div>
+            <Form.Control
+              as="textarea"
+              placeholder="Enter markdown here..."
+              ref={editorRef}
+              onScroll={handleEditorScroll}
+              className="editor"
+              value={markdown}
+              onChange={(e) => setMarkdown(e.target.value)}
+            />
+          </div>
         </Col>
-        <Col md={6} className="p-0">
-          <div
-            ref={previewRef}
-            onScroll={handlePreviewScroll}
-            className={`preview ${template === "github" ? "markdown-body" : ""}`}
-            dangerouslySetInnerHTML={{ __html: marked(markdown) }}
-          ></div>
-        </Col>
+        {previewVisible && (
+          <Col md={6} className="p-0 sidebar">
+            <div
+              ref={previewRef}
+              onScroll={handlePreviewScroll}
+              className={`preview ${
+                template === "github"
+                  ? "markdown-body"
+                  : template === "simple"
+                  ? "simple-template"
+                  : "word-template"
+              }`}
+              dangerouslySetInnerHTML={{ __html: marked(markdown) }}
+            ></div>
+          </Col>
+        )}
       </Row>
     </Container>
   );

--- a/src/components/line.css
+++ b/src/components/line.css
@@ -21,3 +21,16 @@
   color: #fff;
 }
 
+.editor-container {
+  display: flex;
+}
+
+.editor-container .line-numbers {
+  overflow: hidden;
+  user-select: none;
+}
+
+.editor-container .editor {
+  flex: 1;
+}
+

--- a/src/components/templates.css
+++ b/src/components/templates.css
@@ -1,0 +1,18 @@
+/* Additional templates */
+
+.simple-template {
+  font-family: "Courier New", monospace;
+  background-color: #f5f5f5;
+  color: #333;
+  padding: 10px;
+}
+
+.word-template {
+  font-family: "Times New Roman", serif;
+  background-color: #ffffff;
+  color: #000;
+  padding: 20px;
+  max-width: 800px;
+  margin: auto;
+  border: 1px solid #e0e0e0;
+}

--- a/src/components/theme.css
+++ b/src/components/theme.css
@@ -18,6 +18,16 @@
   color: #c9d1d9;
 }
 
+.light .line-numbers {
+  background-color: #f0f0f0;
+  color: #000;
+}
+
+.dark .line-numbers {
+  background-color: #2d2d2d;
+  color: #ddd;
+}
+
 .editor {
   width: 100%;
   height: 90vh;
@@ -32,4 +42,8 @@
   height: 90vh;
   border: 1px solid #ccc;
   padding: 10px;
+}
+
+.sidebar {
+  border-left: 1px solid #ccc;
 }


### PR DESCRIPTION
## Summary
- set GitHub template as default
- add simple and word-like templates with CSS styles
- show line numbers for the editor and synchronize scrolling
- make preview pane collapsible like a sidebar
- change toolbar buttons to icons
- update dependencies for Material UI icons

## Testing
- `npm test --silent --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_68403b6539e08327a2ecd610b6d8dd2d