### PR TITLE
Fix dark mode styles for tables and code blocks

### DIFF
--- a/src/components/theme.css
+++ b/src/components/theme.css
@@ -28,6 +28,41 @@
   color: #ddd;
 }
 
+/* Dark mode styles for code blocks and inline code */
+.dark .preview pre,
+.dark .preview code,
+.dark pre code.hljs,
+.dark code.hljs {
+  background-color: #0d1117;
+  color: #c9d1d9;
+  border-color: #30363d;
+}
+
+.dark .hljs {
+  color: #c9d1d9;
+  background: #0d1117;
+}
+
+.dark .preview pre {
+  border: 1px solid #30363d;
+}
+
+/* Dark mode table styling */
+.dark .preview table th,
+.dark .preview table td {
+  border: 1px solid #30363d;
+  color: #c9d1d9;
+}
+
+.dark .preview table tr {
+  background-color: #0d1117;
+  border-top: 1px solid #30363d;
+}
+
+.dark .preview table tr:nth-child(2n) {
+  background-color: #161b22;
+}
+
 .editor {
   width: 100%;
   height: 90vh;


### PR DESCRIPTION
## Summary
- ensure code blocks and tables use dark backgrounds in dark theme

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68404de23b5c8327b86a04edde7ac697