### PR TITLE
Fix dark mode for code blocks and tables

### DIFF
--- a/src/components/theme.css
+++ b/src/components/theme.css
@@ -8,6 +8,14 @@
   color: #ddd;
 }
 
+/* Ensure the editor stays dark when focused */
+.dark .editor:focus {
+  background-color: #1e1e1e;
+  color: #ddd;
+  border-color: #555;
+  box-shadow: none;
+}
+
 .light .markdown-body {
   background-color: #ffffff;
   color: #000000;
@@ -26,6 +34,46 @@
 .dark .line-numbers {
   background-color: #2d2d2d;
   color: #ddd;
+}
+
+/* Dark mode styles for code blocks and inline code */
+.dark .preview pre,
+.dark .preview code,
+.dark pre code.hljs,
+.dark code.hljs {
+  background-color: #0d1117;
+  color: #c9d1d9;
+  border-color: #30363d;
+}
+
+.dark .hljs {
+  color: #c9d1d9;
+  background: #0d1117;
+}
+
+.dark .preview pre {
+  border: 1px solid #30363d;
+}
+
+/* Dark mode table styling */
+.dark .preview table {
+  border-collapse: collapse;
+  border: 1px solid #30363d;
+}
+
+.dark .preview table th,
+.dark .preview table td {
+  border: 1px solid #30363d;
+  color: #c9d1d9;
+}
+
+.dark .preview table tr {
+  background-color: #0d1117;
+  border-top: 1px solid #30363d;
+}
+
+.dark .preview table tr:nth-child(2n) {
+  background-color: #161b22;
 }
 
 .editor {


### PR DESCRIPTION
## Summary
- keep editor focused styling in dark mode
- apply dark theme to code blocks and tables
- ensure tables collapse borders correctly

## Testing
- `npm install`
- `CI=true npm test --silent`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68404de23b5c8327b86a04edde7ac697